### PR TITLE
Refactor Erc20Kit

### DIFF
--- a/app/src/main/java/io/horizontalsystems/ethereumkit/sample/TransactionsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/ethereumkit/sample/TransactionsFragment.kt
@@ -104,6 +104,7 @@ class ViewHolderTransaction(private val containerView: View) : RecyclerView.View
             - From: ${tx.from.address}
             - To: ${tx.to.address}
             - Amount: ${tx.amount.stripTrailingZeros()}
+            - isError: ${tx.isError}
         """
 
         if (lastBlockHeight > 0)

--- a/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/EtherscanTransactionsProvider.kt
+++ b/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/EtherscanTransactionsProvider.kt
@@ -1,0 +1,35 @@
+package io.horizontalsystems.erc20kit.core
+
+import io.horizontalsystems.erc20kit.models.Transaction
+import io.horizontalsystems.ethereumkit.core.hexStringToByteArray
+import io.horizontalsystems.ethereumkit.network.EtherscanService
+import io.reactivex.Single
+
+class EtherscanTransactionsProvider(private val etherscanService: EtherscanService) : ITransactionsProvider {
+
+    override fun getTransactions(contractAddress: ByteArray, address: ByteArray, from: Long, to: Long): Single<List<Transaction>> {
+        return etherscanService.getTokenTransactions(contractAddress, address, from)
+                .map { response ->
+                    val transactionIndexMap = mutableMapOf<String, Int>()
+
+                    response.result.map { etherscanTx ->
+                        val interTransactionIndex = transactionIndexMap[etherscanTx.hash]?.plus(1) ?: 0
+                        transactionIndexMap[etherscanTx.hash] = interTransactionIndex
+
+                        val transaction = Transaction(etherscanTx.hash.hexStringToByteArray(),
+                                interTransactionIndex,
+                                etherscanTx.transactionIndex.toIntOrNull(),
+                                etherscanTx.from.hexStringToByteArray(),
+                                etherscanTx.to.hexStringToByteArray(),
+                                etherscanTx.value.toBigInteger(),
+                                etherscanTx.timeStamp.toLong())
+
+                        transaction.blockHash = etherscanTx.blockHash.hexStringToByteArray()
+                        transaction.blockNumber = etherscanTx.blockNumber.toLongOrNull()
+
+                        transaction
+                    }
+                }
+    }
+
+}

--- a/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/Interfaces.kt
+++ b/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/Interfaces.kt
@@ -17,11 +17,10 @@ interface ITransactionManagerListener {
 interface ITransactionManager {
     var listener: ITransactionManagerListener?
 
-    val lastTransactionBlockHeight: Long?
     fun getTransactions(fromTransaction: TransactionKey?, limit: Int?): Single<List<Transaction>>
     fun sync()
     fun send(to: ByteArray, value: BigInteger, gasPrice: Long, gasLimit: Long): Single<Transaction>
-    fun getTransactionInput(to: ByteArray, value: BigInteger):ByteArray
+    fun getTransactionInput(to: ByteArray, value: BigInteger): ByteArray
 }
 
 interface IBalanceManagerListener {
@@ -42,6 +41,10 @@ interface ITransactionStorage {
     fun getTransactions(fromTransaction: TransactionKey?, limit: Int?): Single<List<Transaction>>
     fun getPendingTransactions(): List<Transaction>
     fun save(transactions: List<Transaction>)
+}
+
+interface ITransactionsProvider {
+    fun getTransactions(contractAddress: ByteArray, address: ByteArray, from: Long, to: Long): Single<List<Transaction>>
 }
 
 interface ITokenBalanceStorage {

--- a/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/TransactionManager.kt
+++ b/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/TransactionManager.kt
@@ -1,10 +1,7 @@
 package io.horizontalsystems.erc20kit.core
 
 import io.horizontalsystems.erc20kit.models.Transaction
-import io.horizontalsystems.ethereumkit.core.hexStringToByteArray
-import io.horizontalsystems.ethereumkit.models.EthereumLog
 import io.horizontalsystems.ethereumkit.models.TransactionStatus
-import io.horizontalsystems.ethereumkit.spv.core.toBigInteger
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -16,88 +13,75 @@ class TransactionManager(
         private val contractAddress: ByteArray,
         private val address: ByteArray,
         private val storage: ITransactionStorage,
+        private val transactionsProvider: ITransactionsProvider,
         private val dataProvider: IDataProvider,
-        private val transactionBuilder: ITransactionBuilder)
-    : ITransactionManager {
+        private val transactionBuilder: ITransactionBuilder) : ITransactionManager {
 
     private val scheduler = Schedulers.from(Executors.newSingleThreadExecutor())
-
     private val logger = Logger.getLogger("TransactionManager")
     private val disposables = CompositeDisposable()
+
     override var listener: ITransactionManagerListener? = null
-    override val lastTransactionBlockHeight: Long?
-        get() = storage.lastTransactionBlockHeight
 
     override fun getTransactions(fromTransaction: TransactionKey?, limit: Int?): Single<List<Transaction>> {
         return storage.getTransactions(fromTransaction, limit)
     }
 
-    private fun handleLogs(logs: List<EthereumLog>) {
-        val nonZeroLogs = logs.filter { log ->
-            logs.count { it.transactionHash.contentEquals(log.transactionHash) } == 1 ||
-                    log.data.hexStringToByteArray().toBigInteger() != BigInteger.ZERO
-        }
+    override fun sync() {
+        val lastBlockHeight = dataProvider.lastBlockHeight
+        val lastTransactionBlockHeight = storage.lastTransactionBlockHeight ?: 0
 
-        val pendingTransactions = storage.getPendingTransactions()
-
-        val updatedTransactions = nonZeroLogs.map { log ->
-            var interTransactionIndex = log.logIndex
-            val value = log.data.hexStringToByteArray().toBigInteger()
-            val from = log.topics[1].hexStringToByteArray().copyOfRange(12, 32)
-            val to = log.topics[2].hexStringToByteArray().copyOfRange(12, 32)
-
-            if (pendingTransactions.count {
-                        it.transactionHash.contentEquals(log.transactionHash.hexStringToByteArray())
-                                && it.from.contentEquals(from)
-                                && it.to.contentEquals(to)
-                    } > 0) {
-                interTransactionIndex = 0
-            }
-
-            val transaction = Transaction(
-                    transactionHash = log.transactionHash.hexStringToByteArray(),
-                    interTransactionIndex = interTransactionIndex,
-                    transactionIndex = log.transactionIndex,
-                    from = from,
-                    to = to,
-                    value = value,
-                    timestamp = log.timestamp ?: System.currentTimeMillis() / 1000)
-
-            transaction.logIndex = log.logIndex
-            transaction.blockHash = log.blockHash.hexStringToByteArray()
-            transaction.blockNumber = log.blockNumber
-
-            transaction
-        }
-
-        if(pendingTransactions.isEmpty()){
-            finishSync(updatedTransactions)
-            return
-        }
-
-        dataProvider.getTransactionStatuses(pendingTransactions.map { it.transactionHash })
-                .observeOn(scheduler)
-                .map { statuses ->
-                    updateFailStatus(pendingTransactions, statuses)
-                }.subscribe(
-                        { failedTransactions ->
-                            failedTransactions?.let {
-                                finishSync(updatedTransactions.plus(failedTransactions))
-                            }
-                        },
-                        { error -> finishSync(updatedTransactions) })
+        transactionsProvider.getTransactions(contractAddress, address, lastTransactionBlockHeight + 1, lastBlockHeight)
+                .subscribeOn(scheduler)
+                .subscribe({ transactions ->
+                    handleTransactions(transactions.filter { it.value != BigInteger.ZERO })
+                }, {
+                    logger.warning("Transaction sync error: ${it.message}")
+                    listener?.onSyncTransactionsError()
+                })
                 .let {
                     disposables.add(it)
                 }
     }
 
-    private fun finishSync(transactions: List<Transaction>) {
-        storage.save(transactions)
-        listener?.onSyncSuccess(transactions)
+    private fun handleTransactions(transactions: List<Transaction>) {
+        val pendingTransactions = storage.getPendingTransactions().toMutableList()
+
+        transactions.forEach { transaction ->
+            val pendingTransactionIndex = pendingTransactions.indexOfFirst {
+                it.transactionHash.contentEquals(transaction.transactionHash)
+                        && it.from.contentEquals(transaction.from)
+                        && it.to.contentEquals(transaction.to)
+            }
+
+            if (pendingTransactionIndex > 0) {
+                // when this transaction was sent interTransactionIndex was set to 0, so we need it to set 0 for it to replace the transaction in database
+                transaction.interTransactionIndex = 0
+                pendingTransactions.removeAt(pendingTransactionIndex)
+            }
+        }
+
+        if (pendingTransactions.isEmpty()) {
+            finishSync(transactions)
+            return
+        }
+
+        dataProvider.getTransactionStatuses(pendingTransactions.map { it.transactionHash })
+                .map { statuses ->
+                    transactions.plus(getFailedTransactions(pendingTransactions, statuses))
+                }
+                .subscribeOn(scheduler)
+                .subscribe({ allTransactions ->
+                    finishSync(allTransactions)
+                }, {
+                    finishSync(transactions)
+                }).let {
+                    disposables.add(it)
+                }
     }
 
-    private fun updateFailStatus(pendingTransactions: List<Transaction>,
-                                 statuses: Map<ByteArray, TransactionStatus>): List<Transaction>? {
+    private fun getFailedTransactions(pendingTransactions: List<Transaction>,
+                                      statuses: Map<ByteArray, TransactionStatus>): List<Transaction> {
         return statuses.mapNotNull { (hash, status) ->
             if (status == TransactionStatus.FAILED || status == TransactionStatus.NOTFOUND) {
                 pendingTransactions.find { it.transactionHash.contentEquals(hash) }?.let { foundTx ->
@@ -110,21 +94,9 @@ class TransactionManager(
         }
     }
 
-    override fun sync() {
-        val lastBlockHeight = dataProvider.lastBlockHeight
-        val lastTransactionBlockHeight = storage.lastTransactionBlockHeight ?: 0
-
-        dataProvider.getTransactionLogs(contractAddress, address, lastTransactionBlockHeight + 1, lastBlockHeight)
-                .subscribeOn(scheduler)
-                .subscribe({ logs ->
-                               handleLogs(logs)
-                           }, {
-                               logger.warning("Transaction sync error: ${it.message}")
-                               listener?.onSyncTransactionsError()
-                           })
-                .let {
-                    disposables.add(it)
-                }
+    private fun finishSync(transactions: List<Transaction>) {
+        storage.save(transactions)
+        listener?.onSyncSuccess(transactions)
     }
 
     override fun send(to: ByteArray, value: BigInteger, gasPrice: Long, gasLimit: Long): Single<Transaction> {
@@ -133,9 +105,9 @@ class TransactionManager(
         return dataProvider.send(contractAddress, transactionInput, gasPrice, gasLimit)
                 .map { hash ->
                     Transaction(transactionHash = hash,
-                                from = address,
-                                to = to,
-                                value = value)
+                            from = address,
+                            to = to,
+                            value = value)
                 }.doOnSuccess { transaction ->
                     storage.save(listOf(transaction))
                 }

--- a/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/TransactionsProvider.kt
+++ b/erc20kit/src/main/java/io/horizontalsystems/erc20kit/core/TransactionsProvider.kt
@@ -1,0 +1,39 @@
+package io.horizontalsystems.erc20kit.core
+
+import io.horizontalsystems.erc20kit.models.Transaction
+import io.horizontalsystems.ethereumkit.core.hexStringToByteArray
+import io.horizontalsystems.ethereumkit.models.EthereumLog
+import io.horizontalsystems.ethereumkit.spv.core.toBigInteger
+import io.reactivex.Single
+
+class TransactionsProvider(private val dataProvider: IDataProvider) : ITransactionsProvider {
+
+    override fun getTransactions(contractAddress: ByteArray, address: ByteArray, from: Long, to: Long): Single<List<Transaction>> {
+        return dataProvider.getTransactionLogs(contractAddress, address, from, to)
+                .map { logs ->
+                    logs.mapNotNull { getTransactionFromLog(it) }
+                }
+    }
+
+    private fun getTransactionFromLog(log: EthereumLog): Transaction? {
+        val value = log.data.hexStringToByteArray().toBigInteger()
+        val from = log.topics[1].hexStringToByteArray().copyOfRange(12, 32)
+        val to = log.topics[2].hexStringToByteArray().copyOfRange(12, 32)
+
+        val transaction = Transaction(
+                transactionHash = log.transactionHash.hexStringToByteArray(),
+                interTransactionIndex = log.logIndex,
+                transactionIndex = log.transactionIndex,
+                from = from,
+                to = to,
+                value = value,
+                timestamp = log.timestamp ?: System.currentTimeMillis() / 1000)
+
+        transaction.logIndex = log.logIndex
+        transaction.blockHash = log.blockHash.hexStringToByteArray()
+        transaction.blockNumber = log.blockNumber
+
+        return transaction
+    }
+
+}

--- a/erc20kit/src/main/java/io/horizontalsystems/erc20kit/models/Transaction.kt
+++ b/erc20kit/src/main/java/io/horizontalsystems/erc20kit/models/Transaction.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 @Entity(primaryKeys = ["transactionHash", "interTransactionIndex"])
 class Transaction(var transactionHash: ByteArray,
-                  val interTransactionIndex: Int = 0,
+                  var interTransactionIndex: Int = 0,
                   var transactionIndex: Int? = null,
                   val from: ByteArray,
                   val to: ByteArray,
@@ -22,11 +22,11 @@ class Transaction(var transactionHash: ByteArray,
         if (other !is Transaction)
             return false
 
-        return transactionHash.contentEquals(other.transactionHash) && logIndex == other.logIndex
+        return transactionHash.contentEquals(other.transactionHash) && interTransactionIndex == other.interTransactionIndex
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(transactionHash, logIndex)
+        return Objects.hash(transactionHash, interTransactionIndex)
     }
 
 }

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
@@ -32,6 +32,7 @@ class EthereumKit(
         private val address: ByteArray,
         val networkType: NetworkType,
         val walletId: String,
+        val etherscanKey: String,
         private val state: EthereumKitState = EthereumKitState())
     : IBlockchainListener, ITransactionManagerListener {
 
@@ -311,7 +312,7 @@ class EthereumKit(
             val addressValidator = AddressValidator()
 
             val ethereumKit = EthereumKit(blockchain, transactionManager, addressValidator, transactionBuilder, address,
-                                          networkType, walletId)
+                                          networkType, walletId, etherscanKey)
 
             blockchain.listener = ethereumKit
             transactionManager.listener = ethereumKit

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/EtherscanService.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/EtherscanService.kt
@@ -57,8 +57,8 @@ class EtherscanService(private val networkType: NetworkType,
         return service.getTransactionList("account", "txList", address.toHexString(), startBlock, 99_999_999, "desc", apiKey)
     }
 
-    fun getTokenTransactions(address: ByteArray, startBlock: Long): Single<EtherscanResponse> {
-        return service.getTokenTransactions("account", "tokentx", address.toHexString(), startBlock, 99_999_999, "desc", apiKey)
+    fun getTokenTransactions(contractAddress: ByteArray, address: ByteArray, startBlock: Long): Single<EtherscanResponse> {
+        return service.getTokenTransactions("account", "tokentx", contractAddress.toHexString(), address.toHexString(), startBlock, 99_999_999, "desc", apiKey)
     }
 
     private interface EtherscanServiceAPI {
@@ -77,6 +77,7 @@ class EtherscanService(private val networkType: NetworkType,
         fun getTokenTransactions(
                 @Query("module") module: String,
                 @Query("action") action: String,
+                @Query("contractaddress") contractAddress: String,
                 @Query("address") address: String,
                 @Query("startblock") startblock: Long,
                 @Query("endblock") endblock: Long,


### PR DESCRIPTION
- extract functionality for fetching transactions to ITransactionsProvider interface
- add 2 implementations:
-- 1) TransactionsProvider - default transactions provider that uses IDataProvider, i.e. EthereumKit
-- 2) EtherscanTransactionsProvider - transactions provider that uses Etherscan API