### PR TITLE
Move replacing of bouncycastle to separate static init method

### DIFF
--- a/app/src/main/java/io/horizontalsystems/ethereumkit/sample/App.kt
+++ b/app/src/main/java/io/horizontalsystems/ethereumkit/sample/App.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.ethereumkit.sample
 
 import android.app.Application
 import com.facebook.stetho.Stetho
+import io.horizontalsystems.ethereumkit.core.EthereumKit
 import io.reactivex.plugins.RxJavaPlugins
 import java.util.logging.Logger
 
@@ -19,6 +20,7 @@ class App : Application() {
 
         // Enable debug bridge
         Stetho.initializeWithDefaults(this)
+        EthereumKit.init()
     }
 
     companion object {

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
@@ -12,6 +12,7 @@ import io.horizontalsystems.ethereumkit.api.models.AccountState
 import io.horizontalsystems.ethereumkit.api.models.EthereumKitState
 import io.horizontalsystems.ethereumkit.api.storage.ApiStorage
 import io.horizontalsystems.ethereumkit.crypto.CryptoUtils
+import io.horizontalsystems.ethereumkit.crypto.InternalBouncyCastleProvider
 import io.horizontalsystems.ethereumkit.models.*
 import io.horizontalsystems.ethereumkit.network.*
 import io.horizontalsystems.ethereumkit.transactionsyncers.*
@@ -21,8 +22,10 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.math.BigInteger
 import java.net.URL
+import java.security.Security
 import java.util.*
 import java.util.logging.Logger
 
@@ -304,6 +307,11 @@ class EthereumKit(
                 .registerTypeAdapter(object : TypeToken<Optional<RpcTransactionReceipt>>() {}.type, OptionalTypeAdapter<RpcTransactionReceipt>(RpcTransactionReceipt::class.java))
                 .registerTypeAdapter(object : TypeToken<Optional<RpcBlock>>() {}.type, OptionalTypeAdapter<RpcBlock>(RpcBlock::class.java))
                 .create()
+
+        fun init() {
+            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+            Security.addProvider(InternalBouncyCastleProvider.getInstance())
+        }
 
         fun getInstance(
                 application: Application,

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/crypto/CryptoUtils.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/crypto/CryptoUtils.kt
@@ -13,7 +13,6 @@ import org.bouncycastle.crypto.modes.SICBlockCipher
 import org.bouncycastle.crypto.params.*
 import org.bouncycastle.crypto.signers.ECDSASigner
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.jce.spec.ECParameterSpec
 import org.bouncycastle.math.ec.ECAlgorithms
 import org.bouncycastle.math.ec.ECCurve
@@ -21,8 +20,6 @@ import org.bouncycastle.math.ec.ECPoint
 import org.bouncycastle.util.BigIntegers
 import java.math.BigInteger
 import java.security.MessageDigest
-import java.security.Provider
-import java.security.Security
 import java.util.*
 
 object CryptoUtils {
@@ -31,8 +28,7 @@ object CryptoUtils {
     val HALF_CURVE_ORDER: BigInteger
     private val CURVE_SPEC: ECParameterSpec
 
-    private val CRYPTO_PROVIDER: Provider
-    private val HASH_256_ALGORITHM_NAME: String
+    private val HASH_256_ALGORITHM_NAME: String = "ETH-KECCAK-256"
 
     const val SECRET_SIZE = 32
     private const val KEY_SIZE = 128
@@ -43,12 +39,6 @@ object CryptoUtils {
         CURVE = ECDomainParameters(params.curve, params.g, params.n, params.h)
         CURVE_SPEC = ECParameterSpec(params.curve, params.g, params.n, params.h)
         HALF_CURVE_ORDER = params.n.shiftRight(1)
-
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(InternalBouncyCastleProvider.getInstance())
-
-        CRYPTO_PROVIDER = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)
-        HASH_256_ALGORITHM_NAME = "ETH-KECCAK-256"
     }
 
     fun ecdhAgree(myKey: ECKey, remotePublicKeyPoint: ECPoint): ByteArray {
@@ -118,7 +108,7 @@ object CryptoUtils {
     }
 
     fun sha3(data: ByteArray): ByteArray {
-        val digest = MessageDigest.getInstance(HASH_256_ALGORITHM_NAME, CRYPTO_PROVIDER)
+        val digest = MessageDigest.getInstance(HASH_256_ALGORITHM_NAME)
         digest.update(data)
         return digest.digest()
     }


### PR DESCRIPTION
Replacing built-in Android Bouncy Castle security provider should be done as early as possible.
Moving it to seperate init method allows to call it, for ex, during application startup.
See https://stackoverflow.com/a/66323575/1073184