### PR TITLE
Fix bug in NodeApiProvider

### DIFF
--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/api/core/NodeApiProvider.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/api/core/NodeApiProvider.kt
@@ -68,7 +68,7 @@ class NodeApiProvider(
                         val response  = rpc.parseResponse(rpcResponse, gson)
 
                         emitter.onSuccess(response)
-                        break
+                        return@create
                     } catch (throwable: Throwable) {
                         error = throwable
                         if (throwable is JsonRpc.ResponseError.RpcError) {


### PR DESCRIPTION
- use return instead of break