### PR TITLE
Fix ConnectionManager by properly unregistering callback

### DIFF
--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
@@ -2,8 +2,6 @@ package io.horizontalsystems.ethereumkit.core
 
 import android.app.Application
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
 import io.horizontalsystems.ethereumkit.api.core.*
@@ -123,22 +121,12 @@ class EthereumKit(
         started = false
         blockchain.stop()
         state.clear()
+        connectionManager.stop()
     }
 
     fun refresh() {
         blockchain.refresh()
         transactionSyncManager.sync()
-    }
-
-    fun onEnterForeground() {
-        connectionManager.onEnterForeground()
-        Handler(Looper.getMainLooper()).postDelayed({
-            blockchain.refresh()
-        }, 1000)
-    }
-
-    fun onEnterBackground() {
-        connectionManager.onEnterBackground()
     }
 
     fun getFullTransactionsFlowable(tags: List<List<String>>): Flowable<List<FullTransaction>> {

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/ConnectionManager.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/ConnectionManager.kt
@@ -15,35 +15,13 @@ class ConnectionManager(context: Context) {
     private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     var listener: Listener? = null
-    var isConnected = false
+    var isConnected = getInitialConnectionStatus()
     private var hasValidInternet = false
     private var hasConnection = false
     private var callback = ConnectionStatusCallback()
 
     init {
-        onEnterForeground()
-    }
-
-    fun onEnterForeground() {
-        setInitialValues()
-        try {
-            connectivityManager.unregisterNetworkCallback(callback)
-        } catch (e: Exception) {
-            //was not registered, or already unregistered
-        }
         connectivityManager.registerNetworkCallback(NetworkRequest.Builder().build(), callback)
-    }
-
-    fun onEnterBackground() {
-        try {
-            connectivityManager.unregisterNetworkCallback(callback)
-        } catch (e: Exception) {
-            //already unregistered
-        }
-    }
-
-    private fun setInitialValues() {
-        isConnected = getInitialConnectionStatus()
     }
 
     private fun getInitialConnectionStatus(): Boolean {
@@ -91,6 +69,14 @@ class ConnectionManager(context: Context) {
         isConnected = hasConnection && hasValidInternet
         if (oldValue != isConnected) {
             listener?.onConnectionChange()
+        }
+    }
+
+    fun stop() {
+        try {
+            connectivityManager.unregisterNetworkCallback(callback)
+        } catch (e: Exception) {
+            //already unregistered
         }
     }
 }


### PR DESCRIPTION
- Add method `stop()` that unregisters ConnectivityManager callback

[#4858](https://github.com/horizontalsystems/unstoppable-wallet-android/issues/4858)