### PR TITLE
Expose the 1inch swap disableEstimate flag

### DIFF
--- a/oneinchkit/src/main/java/io/horizontalsystems/oneinchkit/OneInchKit.kt
+++ b/oneinchkit/src/main/java/io/horizontalsystems/oneinchkit/OneInchKit.kt
@@ -63,6 +63,7 @@ class OneInchKit(
         complexityLevel: Int? = null,
         connectorTokens: List<String>? = null,
         allowPartialFill: Boolean = false,
+        disableEstimate: Boolean? = null,
         gasLimit: Long? = null,
         parts: Int? = null,
         mainRouteParts: Int? = null
@@ -82,6 +83,7 @@ class OneInchKit(
         complexityLevel,
         connectorTokens,
         allowPartialFill,
+        disableEstimate,
         gasLimit,
         parts,
         mainRouteParts

--- a/oneinchkit/src/main/java/io/horizontalsystems/oneinchkit/OneInchService.kt
+++ b/oneinchkit/src/main/java/io/horizontalsystems/oneinchkit/OneInchService.kt
@@ -125,6 +125,7 @@ class OneInchService(
         complexityLevel: Int? = null,
         connectorTokens: List<String>? = null,
         allowPartialFill: Boolean? = null,
+        disableEstimate: Boolean? = null,
         gasLimit: Long? = null,
         parts: Int? = null,
         mainRouteParts: Int? = null
@@ -146,6 +147,7 @@ class OneInchService(
             complexityLevel = complexityLevel,
             connectorTokens = connectorTokens?.joinToString(","),
             allowPartialFill = allowPartialFill,
+            disableEstimate = disableEstimate,
             gasLimit = gasLimit,
             parts = parts,
             mainRouteParts = mainRouteParts
@@ -167,6 +169,7 @@ class OneInchService(
             complexityLevel = complexityLevel,
             connectorTokens = connectorTokens?.joinToString(","),
             allowPartialFill = allowPartialFill,
+            disableEstimate = disableEstimate,
             gasLimit = gasLimit,
             parts = parts,
             mainRouteParts = mainRouteParts
@@ -222,6 +225,7 @@ class OneInchService(
             @Query("complexityLevel ") complexityLevel: Int? = null,
             @Query("connectorTokens") connectorTokens: String? = null,
             @Query("allowPartialFill") allowPartialFill: Boolean? = null,
+            @Query("disableEstimate") disableEstimate: Boolean? = null,
             @Query("gasLimit") gasLimit: Long? = null,
             @Query("parts") parts: Int? = null,
             @Query("mainRouteParts") mainRouteParts: Int? = null,


### PR DESCRIPTION
Adds the `disableEstimate` query parameter to the swap endpoint and threads it through `OneInchService.getSwapAsync` and `OneInchKit.getSwapAsync` (default null keeps current behavior).

1inch simulates the sender's allowance/balance server-side before returning swap calldata; callers that batch the token approve into the same operation (allowance still zero at quote time) need the simulation skipped.