### PR TITLE
Add Robinhood chain and integrate with Uniswap

### DIFF
--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/BlockscoutTransactionProvider.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/BlockscoutTransactionProvider.kt
@@ -1,0 +1,183 @@
+package io.horizontalsystems.ethereumkit.core
+
+import io.horizontalsystems.ethereumkit.models.Address
+import io.horizontalsystems.ethereumkit.models.ProviderEip1155Transaction
+import io.horizontalsystems.ethereumkit.models.ProviderEip721Transaction
+import io.horizontalsystems.ethereumkit.models.ProviderInternalTransaction
+import io.horizontalsystems.ethereumkit.models.ProviderTokenTransaction
+import io.horizontalsystems.ethereumkit.models.ProviderTransaction
+import io.horizontalsystems.ethereumkit.network.BlockscoutInternalTransaction
+import io.horizontalsystems.ethereumkit.network.BlockscoutService
+import io.horizontalsystems.ethereumkit.network.BlockscoutTokenTransfer
+import io.reactivex.Single
+import java.time.Instant
+
+/**
+ * [ITransactionProvider] backed by a Blockscout instance's `/api/v2` REST API.
+ *
+ * The v2 endpoints do not carry every field the legacy Etherscan API does. Missing fields that are
+ * not used when building [io.horizontalsystems.ethereumkit.models.Transaction] records or decorating
+ * them (e.g. per-token-transfer gas figures, nonce, transaction index) are defaulted to 0; token
+ * transfer fees are taken from the parent transaction record, not the transfer itself.
+ */
+class BlockscoutTransactionProvider(
+    private val service: BlockscoutService,
+    private val address: Address,
+) : ITransactionProvider {
+
+    override fun getTransactions(startBlock: Long): Single<List<ProviderTransaction>> =
+        service.getTransactions(address.hex, startBlock).map { transactions ->
+            transactions.mapNotNull { tx ->
+                try {
+                    val success = tx.status == "ok"
+                    ProviderTransaction(
+                        blockNumber = tx.blockNumber!!,
+                        timestamp = parseTimestamp(tx.timestamp),
+                        hash = tx.hash!!.hexStringToByteArray(),
+                        nonce = tx.nonce ?: 0,
+                        blockHash = null,
+                        transactionIndex = tx.position ?: 0,
+                        from = Address(tx.from!!.hash!!),
+                        to = tx.to?.hash?.let { Address(it) },
+                        value = tx.value!!.toBigInteger(),
+                        gasLimit = tx.gasLimit?.toLong() ?: 0,
+                        gasPrice = tx.gasPrice?.toLong() ?: 0,
+                        isError = if (success) 0 else 1,
+                        txReceiptStatus = if (success) 1 else 0,
+                        input = tx.rawInput?.hexStringToByteArray() ?: ByteArray(0),
+                        cumulativeGasUsed = null,
+                        gasUsed = tx.gasUsed?.toLongOrNull()
+                    )
+                } catch (throwable: Throwable) {
+                    null
+                }
+            }
+        }
+
+    override fun getInternalTransactions(startBlock: Long): Single<List<ProviderInternalTransaction>> =
+        service.getInternalTransactions(address.hex, startBlock).map { internalTransactions ->
+            internalTransactions.mapNotNull { mapInternalTransaction(it) }
+        }
+
+    override fun getInternalTransactionsAsync(hash: ByteArray): Single<List<ProviderInternalTransaction>> =
+        service.getInternalTransactions(hash.toHexString()).map { internalTransactions ->
+            internalTransactions.mapNotNull { mapInternalTransaction(it) }
+        }
+
+    override fun getTokenTransactions(startBlock: Long): Single<List<ProviderTokenTransaction>> =
+        service.getTokenTransfers(address.hex, ERC20, startBlock).map { transfers ->
+            transfers.mapNotNull { transfer ->
+                try {
+                    ProviderTokenTransaction(
+                        blockNumber = transfer.blockNumber!!,
+                        timestamp = parseTimestamp(transfer.timestamp),
+                        hash = transfer.transactionHash!!.hexStringToByteArray(),
+                        nonce = 0,
+                        blockHash = transfer.blockHash?.hexStringToByteArray() ?: ByteArray(0),
+                        from = Address(transfer.from!!.hash!!),
+                        contractAddress = Address(transfer.token!!.addressHash!!),
+                        to = Address(transfer.to!!.hash!!),
+                        value = transfer.total!!.value!!.toBigInteger(),
+                        tokenName = transfer.token.name ?: "",
+                        tokenSymbol = transfer.token.symbol ?: "",
+                        tokenDecimal = transfer.token.decimals?.toIntOrNull() ?: 0,
+                        transactionIndex = 0,
+                        gasLimit = 0,
+                        gasPrice = 0,
+                        gasUsed = 0,
+                        cumulativeGasUsed = 0
+                    )
+                } catch (throwable: Throwable) {
+                    null
+                }
+            }
+        }
+
+    override fun getEip721Transactions(startBlock: Long): Single<List<ProviderEip721Transaction>> =
+        service.getTokenTransfers(address.hex, ERC721, startBlock).map { transfers ->
+            transfers.mapNotNull { transfer ->
+                try {
+                    ProviderEip721Transaction(
+                        blockNumber = transfer.blockNumber!!,
+                        timestamp = parseTimestamp(transfer.timestamp),
+                        hash = transfer.transactionHash!!.hexStringToByteArray(),
+                        nonce = 0,
+                        blockHash = transfer.blockHash?.hexStringToByteArray() ?: ByteArray(0),
+                        transactionIndex = 0,
+                        gasLimit = 0,
+                        gasPrice = 0,
+                        gasUsed = 0,
+                        cumulativeGasUsed = 0,
+                        contractAddress = Address(transfer.token!!.addressHash!!),
+                        from = Address(transfer.from!!.hash!!),
+                        to = Address(transfer.to!!.hash!!),
+                        tokenId = transfer.total!!.tokenId!!.toBigInteger(),
+                        tokenName = transfer.token.name ?: "",
+                        tokenSymbol = transfer.token.symbol ?: "",
+                        tokenDecimal = transfer.token.decimals?.toIntOrNull() ?: 0
+                    )
+                } catch (throwable: Throwable) {
+                    null
+                }
+            }
+        }
+
+    override fun getEip1155Transactions(startBlock: Long): Single<List<ProviderEip1155Transaction>> =
+        service.getTokenTransfers(address.hex, ERC1155, startBlock).map { transfers ->
+            transfers.mapNotNull { transfer ->
+                try {
+                    ProviderEip1155Transaction(
+                        blockNumber = transfer.blockNumber!!,
+                        timestamp = parseTimestamp(transfer.timestamp),
+                        hash = transfer.transactionHash!!.hexStringToByteArray(),
+                        nonce = 0,
+                        blockHash = transfer.blockHash?.hexStringToByteArray() ?: ByteArray(0),
+                        transactionIndex = 0,
+                        gasLimit = 0,
+                        gasPrice = 0,
+                        gasUsed = 0,
+                        cumulativeGasUsed = 0,
+                        contractAddress = Address(transfer.token!!.addressHash!!),
+                        from = Address(transfer.from!!.hash!!),
+                        to = Address(transfer.to!!.hash!!),
+                        tokenId = transfer.total!!.tokenId!!.toBigInteger(),
+                        tokenValue = transfer.total.value?.toIntOrNull() ?: 0,
+                        tokenName = transfer.token.name ?: "",
+                        tokenSymbol = transfer.token.symbol ?: ""
+                    )
+                } catch (throwable: Throwable) {
+                    null
+                }
+            }
+        }
+
+    private fun mapInternalTransaction(internalTx: BlockscoutInternalTransaction): ProviderInternalTransaction? =
+        try {
+            ProviderInternalTransaction(
+                hash = internalTx.transactionHash!!.hexStringToByteArray(),
+                blockNumber = internalTx.blockNumber!!,
+                timestamp = parseTimestamp(internalTx.timestamp),
+                from = Address(internalTx.from!!.hash!!),
+                to = Address(internalTx.to!!.hash!!),
+                value = internalTx.value!!.toBigInteger(),
+                traceId = (internalTx.index ?: 0).toString()
+            )
+        } catch (throwable: Throwable) {
+            null
+        }
+
+    private fun parseTimestamp(timestamp: String?): Long =
+        timestamp?.let {
+            try {
+                Instant.parse(it).epochSecond
+            } catch (throwable: Throwable) {
+                null
+            }
+        } ?: 0
+
+    companion object {
+        private const val ERC20 = "ERC-20"
+        private const val ERC721 = "ERC-721"
+        private const val ERC1155 = "ERC-1155"
+    }
+}

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/core/EthereumKit.kt
@@ -38,6 +38,7 @@ import io.horizontalsystems.ethereumkit.models.TransactionLog
 import io.horizontalsystems.ethereumkit.models.TransactionSource
 import io.horizontalsystems.ethereumkit.network.AddressTypeAdapter
 import io.horizontalsystems.ethereumkit.network.BigIntegerTypeAdapter
+import io.horizontalsystems.ethereumkit.network.BlockscoutService
 import io.horizontalsystems.ethereumkit.network.ByteArrayTypeAdapter
 import io.horizontalsystems.ethereumkit.network.ConnectionManager
 import io.horizontalsystems.ethereumkit.network.DefaultBlockParameterTypeAdapter
@@ -538,10 +539,14 @@ class EthereumKit(
         }
 
         private fun transactionProvider(transactionSource: TransactionSource, address: Address, chainId: Int): ITransactionProvider {
-            when (transactionSource.type) {
+            return when (val type = transactionSource.type) {
                 is TransactionSource.SourceType.Etherscan -> {
-                    val service = EtherscanService(transactionSource.type.apiBaseUrl, transactionSource.type.apiKeys, chainId)
-                    return EtherscanTransactionProvider(service, address)
+                    val service = EtherscanService(type.apiBaseUrl, type.apiKeys, chainId)
+                    EtherscanTransactionProvider(service, address)
+                }
+                is TransactionSource.SourceType.Blockscout -> {
+                    val service = BlockscoutService(type.apiBaseUrl, type.apiKeys)
+                    BlockscoutTransactionProvider(service, address)
                 }
             }
         }

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/Chain.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/Chain.kt
@@ -14,6 +14,7 @@ enum class Chain(
     Polygon(137, 60, 10_000_000, 15, true),
     Optimism(10, 60, 10_000_000, 15, true),
     ArbitrumOne(42161, 60, 10_000_000, 15, true),
+    RobinhoodChain(4663, 60, 10_000_000, 15, true),
     Avalanche(43114, 60, 10_000_000, 15, true),
     Gnosis(100, 60, 10_000_000, 15, true),
     Fantom(250, 60, 10_000_000, 15, false),

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/TransactionSource.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/TransactionSource.kt
@@ -58,6 +58,20 @@ class TransactionSource(val name: String, val type: SourceType) {
             return etherscan("era.zksync.network", "https://era.zksync.network", apiKeys)
         }
 
+        // Robinhood Chain is an Arbitrum Orbit L2 not indexed by Etherscan; it exposes a
+        // Blockscout instance whose legacy /api endpoint is Etherscan-compatible. Point the
+        // API base at Blockscout directly instead of the shared Etherscan v2 endpoint.
+        fun robinhood(apiKeys: List<String>): TransactionSource {
+            return TransactionSource(
+                "robinhoodchain.blockscout.com",
+                SourceType.Etherscan(
+                    apiBaseUrl = "https://robinhoodchain.blockscout.com/",
+                    txBaseUrl = "https://robinhoodchain.blockscout.com",
+                    apiKeys = apiKeys
+                )
+            )
+        }
+
     }
 
 }

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/TransactionSource.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/models/TransactionSource.kt
@@ -5,10 +5,15 @@ class TransactionSource(val name: String, val type: SourceType) {
     fun transactionUrl(hash: String) =
         when (type) {
             is SourceType.Etherscan -> "${type.txBaseUrl}/tx/$hash"
+            is SourceType.Blockscout -> "${type.txBaseUrl}/tx/$hash"
         }
 
     sealed class SourceType {
         class Etherscan(val apiBaseUrl: String, val txBaseUrl: String, val apiKeys: List<String>) : SourceType()
+
+        // Blockscout's modern REST API (/api/v2). Used for chains whose Blockscout instance
+        // throttles the legacy Etherscan-compatible /api endpoint for anonymous callers.
+        class Blockscout(val apiBaseUrl: String, val txBaseUrl: String, val apiKeys: List<String>) : SourceType()
     }
 
     companion object {
@@ -59,12 +64,13 @@ class TransactionSource(val name: String, val type: SourceType) {
         }
 
         // Robinhood Chain is an Arbitrum Orbit L2 not indexed by Etherscan; it exposes a
-        // Blockscout instance whose legacy /api endpoint is Etherscan-compatible. Point the
-        // API base at Blockscout directly instead of the shared Etherscan v2 endpoint.
+        // Blockscout instance. Its legacy Etherscan-compatible /api endpoint hard-throttles
+        // anonymous callers (HTTP 429 "Too many requests"), so transaction history never loads
+        // there. The modern /api/v2 REST endpoint is not throttled, so use that instead.
         fun robinhood(apiKeys: List<String>): TransactionSource {
             return TransactionSource(
                 "robinhoodchain.blockscout.com",
-                SourceType.Etherscan(
+                SourceType.Blockscout(
                     apiBaseUrl = "https://robinhoodchain.blockscout.com/",
                     txBaseUrl = "https://robinhoodchain.blockscout.com",
                     apiKeys = apiKeys

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/BlockscoutService.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/BlockscoutService.kt
@@ -1,0 +1,229 @@
+package io.horizontalsystems.ethereumkit.network
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+import io.horizontalsystems.ethereumkit.core.retryWhenError
+import io.horizontalsystems.ethereumkit.network.EtherscanService.RequestError
+import io.reactivex.Single
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+import retrofit2.http.QueryMap
+import java.util.logging.Logger
+
+/**
+ * Talks to a Blockscout instance's modern REST API (`/api/v2`). Unlike the legacy
+ * Etherscan-compatible `/api` endpoint (see [EtherscanService]), the v2 endpoints are not
+ * hard-throttled for anonymous callers.
+ *
+ * The v2 endpoints are cursor-paginated (newest first). Each response carries an opaque
+ * `next_page_params` object that is echoed back as query params to fetch the next page. Since
+ * results are ordered by descending block number, paging stops as soon as a page contains an
+ * item older than [startBlock], or after [MAX_PAGES] pages as a safety bound on the initial sync.
+ */
+class BlockscoutService(
+    baseUrl: String,
+    private val apiKeys: List<String>,
+) {
+    private val logger = Logger.getLogger("BlockscoutService")
+    private val service: BlockscoutServiceAPI
+
+    // Non-throttled key raises limits when present; Blockscout ignores it otherwise.
+    private val apiKey: String? = apiKeys.firstOrNull()?.takeIf { it.isNotBlank() }
+
+    init {
+        val loggingInterceptor = HttpLoggingInterceptor { logger.info(it) }
+            .setLevel(HttpLoggingInterceptor.Level.BASIC)
+
+        val httpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "Mobile App Agent")
+                    .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(loggingInterceptor)
+
+        val gson = GsonBuilder().setLenient().create()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(baseUrl)
+            // Async adapter (enqueue, not execute): TransactionSyncManager zips the per-address
+            // syncers, and a synchronous adapter would block the single subscribe thread, running
+            // the (slow) Blockscout requests one-after-another. Async lets them run concurrently,
+            // so the first-sync wait is the slowest request, not the sum of all of them.
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .client(httpClient.build())
+            .build()
+
+        service = retrofit.create(BlockscoutServiceAPI::class.java)
+    }
+
+    fun getTransactions(address: String, startBlock: Long): Single<List<BlockscoutTransaction>> =
+        fetchPages(startBlock, { it.blockNumber }) { params ->
+            service.transactions(address, apiKey, params)
+        }
+
+    fun getInternalTransactions(address: String, startBlock: Long): Single<List<BlockscoutInternalTransaction>> =
+        fetchPages(startBlock, { it.blockNumber }) { params ->
+            service.internalTransactions(address, apiKey, params)
+        }
+
+    fun getInternalTransactions(txHash: String): Single<List<BlockscoutInternalTransaction>> =
+        fetchPages(0, { it.blockNumber }) { params ->
+            service.transactionInternalTransactions(txHash, apiKey, params)
+        }
+
+    fun getTokenTransfers(address: String, type: String, startBlock: Long): Single<List<BlockscoutTokenTransfer>> =
+        fetchPages(startBlock, { it.blockNumber }) { params ->
+            service.tokenTransfers(address, type, apiKey, params)
+        }
+
+    private fun <T> fetchPages(
+        startBlock: Long,
+        blockNumberOf: (T) -> Long?,
+        call: (Map<String, String>) -> Single<Page<T>>,
+    ): Single<List<T>> {
+        val accumulated = mutableListOf<T>()
+
+        fun nextPage(params: Map<String, String>, page: Int): Single<List<T>> =
+            call(params).flatMap { response ->
+                val items = response.items.orEmpty()
+                var reachedOlder = false
+                for (item in items) {
+                    val blockNumber = blockNumberOf(item) ?: 0
+                    if (blockNumber < startBlock) {
+                        reachedOlder = true
+                    } else {
+                        accumulated.add(item)
+                    }
+                }
+
+                val nextParams = response.nextPageParams?.toStringMap()
+                if (reachedOlder || nextParams.isNullOrEmpty() || page + 1 >= MAX_PAGES) {
+                    Single.just(accumulated.toList())
+                } else {
+                    nextPage(nextParams, page + 1)
+                }
+            }
+
+        return nextPage(emptyMap(), 0).retryWhenError(RequestError.RateLimitExceed::class)
+    }
+
+    // next_page_params is a JSON object on non-final pages and JSON null on the last page. It must
+    // be typed as JsonElement, not JsonObject: Gson's JsonObject adapter throws on a null value,
+    // which would fail the whole page parse (and thus drop every single-page result).
+    private fun JsonElement.toStringMap(): Map<String, String> {
+        if (!isJsonObject) return emptyMap()
+        val map = mutableMapOf<String, String>()
+        for ((key, value) in asJsonObject.entrySet()) {
+            if (value != null && !value.isJsonNull) {
+                map[key] = value.asString
+            }
+        }
+        return map
+    }
+
+    companion object {
+        private const val MAX_PAGES = 20
+    }
+
+    private interface BlockscoutServiceAPI {
+        @GET("api/v2/addresses/{address}/transactions")
+        fun transactions(
+            @Path("address") address: String,
+            @Query("apikey") apiKey: String?,
+            @QueryMap params: Map<String, String>,
+        ): Single<Page<BlockscoutTransaction>>
+
+        @GET("api/v2/addresses/{address}/internal-transactions")
+        fun internalTransactions(
+            @Path("address") address: String,
+            @Query("apikey") apiKey: String?,
+            @QueryMap params: Map<String, String>,
+        ): Single<Page<BlockscoutInternalTransaction>>
+
+        @GET("api/v2/transactions/{txHash}/internal-transactions")
+        fun transactionInternalTransactions(
+            @Path("txHash") txHash: String,
+            @Query("apikey") apiKey: String?,
+            @QueryMap params: Map<String, String>,
+        ): Single<Page<BlockscoutInternalTransaction>>
+
+        @GET("api/v2/addresses/{address}/token-transfers")
+        fun tokenTransfers(
+            @Path("address") address: String,
+            @Query("type") type: String,
+            @Query("apikey") apiKey: String?,
+            @QueryMap params: Map<String, String>,
+        ): Single<Page<BlockscoutTokenTransfer>>
+    }
+}
+
+class Page<T>(
+    @SerializedName("items") val items: List<T>?,
+    @SerializedName("next_page_params") val nextPageParams: JsonElement?,
+)
+
+class BlockscoutAddress(
+    @SerializedName("hash") val hash: String?,
+)
+
+class BlockscoutToken(
+    @SerializedName("address_hash") val addressHash: String?,
+    @SerializedName("name") val name: String?,
+    @SerializedName("symbol") val symbol: String?,
+    @SerializedName("decimals") val decimals: String?,
+    @SerializedName("type") val type: String?,
+)
+
+class BlockscoutTotal(
+    @SerializedName("value") val value: String?,
+    @SerializedName("decimals") val decimals: String?,
+    @SerializedName("token_id") val tokenId: String?,
+)
+
+class BlockscoutTransaction(
+    @SerializedName("hash") val hash: String?,
+    @SerializedName("block_number") val blockNumber: Long?,
+    @SerializedName("timestamp") val timestamp: String?,
+    @SerializedName("nonce") val nonce: Long?,
+    @SerializedName("position") val position: Int?,
+    @SerializedName("from") val from: BlockscoutAddress?,
+    @SerializedName("to") val to: BlockscoutAddress?,
+    @SerializedName("value") val value: String?,
+    @SerializedName("gas_limit") val gasLimit: String?,
+    @SerializedName("gas_price") val gasPrice: String?,
+    @SerializedName("gas_used") val gasUsed: String?,
+    @SerializedName("status") val status: String?,
+    @SerializedName("raw_input") val rawInput: String?,
+)
+
+class BlockscoutInternalTransaction(
+    @SerializedName("transaction_hash") val transactionHash: String?,
+    @SerializedName("block_number") val blockNumber: Long?,
+    @SerializedName("timestamp") val timestamp: String?,
+    @SerializedName("from") val from: BlockscoutAddress?,
+    @SerializedName("to") val to: BlockscoutAddress?,
+    @SerializedName("value") val value: String?,
+    @SerializedName("index") val index: Int?,
+)
+
+class BlockscoutTokenTransfer(
+    @SerializedName("transaction_hash") val transactionHash: String?,
+    @SerializedName("block_number") val blockNumber: Long?,
+    @SerializedName("block_hash") val blockHash: String?,
+    @SerializedName("timestamp") val timestamp: String?,
+    @SerializedName("from") val from: BlockscoutAddress?,
+    @SerializedName("to") val to: BlockscoutAddress?,
+    @SerializedName("log_index") val logIndex: Int?,
+    @SerializedName("token") val token: BlockscoutToken?,
+    @SerializedName("total") val total: BlockscoutTotal?,
+)

--- a/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/EtherscanService.kt
+++ b/ethereumkit/src/main/java/io/horizontalsystems/ethereumkit/network/EtherscanService.kt
@@ -142,8 +142,15 @@ class EtherscanService(
             val message = responseObj["message"].asJsonPrimitive.asString
 
             if (status == "0" && message != "No transactions found") {
-                val result = responseObj["result"].asJsonPrimitive.asString
-                if (message == "NOTOK" && result == "Max rate limit reached") {
+                val resultElement = responseObj["result"]
+                val result = if (resultElement != null && resultElement.isJsonPrimitive) resultElement.asString else null
+
+                // Etherscan signals throttling with message "NOTOK" / result "Max rate limit reached";
+                // Blockscout's legacy endpoint uses "Too many requests" with a null result. Surface both
+                // as RateLimitExceed so retryWhenError backs off instead of failing the whole sync.
+                val rateLimited = (message == "NOTOK" && result == "Max rate limit reached") ||
+                        message.contains("Too many requests", ignoreCase = true)
+                if (rateLimited) {
                     throw RequestError.RateLimitExceed()
                 }
             }

--- a/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/TokenFactory.kt
+++ b/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/TokenFactory.kt
@@ -30,6 +30,7 @@ class TokenFactory {
                 Chain.ArbitrumOne -> "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
                 Chain.Base -> "0x4200000000000000000000000000000000000006"
                 Chain.ZkSync -> "0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91"
+                Chain.RobinhoodChain -> "0x0bd7d308f8e1639fab988df18a8011f41eacad73"
                  else -> throw UnsupportedChainError.NoWethAddress
             }
             return Address(wethAddressHex)

--- a/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/pool/PoolManager.kt
+++ b/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/pool/PoolManager.kt
@@ -28,6 +28,7 @@ class PoolManager(
         Chain.BinanceSmartChain -> "0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7"
         Chain.Base -> "0x33128a8fC17869897dcE68Ed026d694621f6FDfD"
         Chain.ZkSync -> "0x8FdA5a7a8dCA67BBcDd10F02Fa0649A937215422"
+        Chain.RobinhoodChain -> "0x1f7d7550b1b028f7571e69a784071f0205fd2efa"
         else -> throw IllegalStateException("Not supported Uniswap chain ${chain}")
     }
 

--- a/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/quoter/QuoterV2.kt
+++ b/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/quoter/QuoterV2.kt
@@ -39,6 +39,7 @@ class QuoterV2(
         Chain.Base -> "0x88F1905197cCb1A94a1EA906F4e973bF6F2248dB"
 
         Chain.ZkSync -> "0x8Cb537fc92E26d8EBBb760E632c95484b6Ea3e28"
+        Chain.RobinhoodChain -> "0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7"
         Chain.EthereumGoerli -> "0x61fFE014bA17989E743c5F6cB21bF9697530B21e"
         else -> throw IllegalStateException("Not supported Uniswap chain $chain")
     }

--- a/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/router/SwapRouter.kt
+++ b/uniswapkit/src/main/java/io/horizontalsystems/uniswapkit/v3/router/SwapRouter.kt
@@ -24,6 +24,7 @@ class SwapRouter(private val dexType: DexType) {
         Chain.Base -> Address("0x8f934fD34A92C1df0DbA4bEfAe7d16CCF255FeBD")
 
         Chain.ZkSync -> Address("0x99c56385daBCE3E81d8499d0b8d0257aBC07E8A3")
+        Chain.RobinhoodChain -> Address("0xcaf681a66d020601342297493863e78c959e5cb2")
         Chain.EthereumGoerli -> Address("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45")
         else -> throw IllegalStateException("Not supported Uniswap chain ${chain}")
     }


### PR DESCRIPTION
This pull request adds support for Robinhood Chain (an Arbitrum Orbit L2) to the EthereumKit and UniswapKit libraries by integrating Blockscout's modern REST API as a transaction provider. It introduces a new `BlockscoutTransactionProvider`, updates the transaction source logic, and makes necessary changes to support Robinhood Chain throughout the codebase.

**Support for Robinhood Chain and Blockscout API:**

* Added `RobinhoodChain` to the `Chain` enum and provided its WETH address in `TokenFactory`, enabling UniswapKit to recognize and interact with Robinhood Chain. [[1]](diffhunk://#diff-bc429f8b3e1c2ee8660fe195ec9ade6703f958447d2653451ffd97e448950a5fR17) [[2]](diffhunk://#diff-0fd9bae14328cbd5feb20b197b3935dc7205b8cb7e88544f10bb005168cb9f6eR33)
* Introduced a new `BlockscoutTransactionProvider` class that implements `ITransactionProvider` using Blockscout's `/api/v2` REST API, supporting transaction, internal, and token transfer queries.
* Added a new `BlockscoutService` class for interacting with Blockscout's REST API, including pagination and rate limit handling.

**Transaction source and provider integration:**

* Extended the `TransactionSource` model to support a new `Blockscout` source type and added a factory method for Robinhood Chain, which uses the Blockscout API instead of the legacy Etherscan-compatible endpoint. [[1]](diffhunk://#diff-0b843e7b9802333e57c43526accfa8b0806649e84134d7325e4a1a8bea182a76R8-R16) [[2]](diffhunk://#diff-0b843e7b9802333e57c43526accfa8b0806649e84134d7325e4a1a8bea182a76R66-R80)
* Updated `EthereumKit` to select `BlockscoutTransactionProvider` when the transaction source is Blockscout-based, ensuring correct provider selection for Robinhood Chain. [[1]](diffhunk://#diff-d3324ba3e4f69ec7819890e2d65254acf21b46db0d93f68a3cf3a7c37c2be1c9R41) [[2]](diffhunk://#diff-d3324ba3e4f69ec7819890e2d65254acf21b46db0d93f68a3cf3a7c37c2be1c9L541-R549)

**Rate limiting improvements:**

* Improved rate limit detection in `EtherscanService` to recognize Blockscout's legacy endpoint throttling responses, ensuring robust error handling and retry logic.